### PR TITLE
Added line deleted in 1c34095 in a conflict resolution.

### DIFF
--- a/moveit_workspace_analysis/CMakeLists.txt
+++ b/moveit_workspace_analysis/CMakeLists.txt
@@ -24,7 +24,7 @@ find_package(catkin REQUIRED COMPONENTS
   cmake_modules
 )
 
-find_package(Eigen REQUIRED)
+find_package(Eigen3 REQUIRED)
 find_package(Boost REQUIRED system filesystem date_time thread)
 
 catkin_package(
@@ -39,10 +39,10 @@ catkin_package(
     interactive_markers
   DEPENDS
     Boost
-    Eigen
+    EIGEN3
 )
 
-include_directories(SYSTEM ${EIGEN_INCLUDE_DIRS}
+include_directories(SYSTEM ${EIGEN3_INCLUDE_DIRS}
                            ${Boost_INCLUDE_DIR}
                            )
 

--- a/moveit_workspace_analysis/README.md
+++ b/moveit_workspace_analysis/README.md
@@ -1,0 +1,43 @@
+moveit_workspace_analysis
+=========================
+
+How to use
+----------
+
+You need to start your robot moveit configuration before starting moveit workspace analysis, for example 
+
+```
+roslaunch  ur5_moveit_config demo.launch
+```
+
+And start analysis program
+
+```
+roslaunch moveit_workspace_analysis workspace_analysis.launch group_name:=manipulator
+```
+
+The `group name` argument must be exist in the moveit configuration settings you include above.
+
+
+To visualize the result, start
+
+```
+roslaunch moveit_workspace_analysis reader.launch
+```
+
+and enable `Display` -> `Marker` -> `/workspace_analysis_results/moveit_workspace_reader/workspace` in your `rviz`
+
+
+Troubleshooting
+---------------
+
+```
+[ERROR] [1516790240.275392209]: No kinematics solver instantiated for group 'right_arm'
+```
+
+This problem occurs when one of the following problems:
+
+- the kinematics.yaml has a typo or does not specify a plugin that can be found for the group you instantiate.
+- the srdf defines your group in a way that is not a chain. Right now there is a check that your group is a chain before trying to run IK for it. I would try defining the group using the <chain> tag in the srdf.
+
+c.f. https://groups.google.com/forum/#!topic/moveit-users/NpbzaXp97KE

--- a/moveit_workspace_analysis/launch/workspace_analysis.launch
+++ b/moveit_workspace_analysis/launch/workspace_analysis.launch
@@ -3,6 +3,7 @@
   <!-- include your robot moveit configuration -->
   <!-- include file="$(find vito_moveit_configuration)/launch/demo.launch"/-->
 
+  <arg name="group_name" default="right_hand_arm"/>
   <arg name="plane_region" default="true"/>
   <arg name="file" default="workspace_analysis_results.txt"/>
   <arg name="namespace" default="ws_analysis"/>
@@ -33,7 +34,7 @@
       <param name="max_attempts" value="40000" />
 
       <!-- group name, it  must exist in the moveit configuration you include above -->
-      <param name="group_name" value="right_hand_arm" />
+      <param name="group_name" value="$(arg group_name)" />
 
       <param name="joint_limits_penalty_multiplier" value="0.0" />
 

--- a/moveit_workspace_analysis/src/main.cpp
+++ b/moveit_workspace_analysis/src/main.cpp
@@ -136,6 +136,7 @@ int main(int argc, char **argv)
   while(!quat_file.eof())
   {
     geometry_msgs::Quaternion temp_quat;
+    quat_file >> temp_quat.x >> temp_quat.y >> temp_quat.z >> temp_quat.w;
     orientations.push_back(temp_quat);
   }
   


### PR DESCRIPTION
This line was deleted in 1c34095 in a conflict resolution. This will fix 
```
terminate called after throwing an instance of 'std::bad_alloc'
```

which was reported in https://groups.google.com/forum/#!topic/moveit-users/E-L5w6hkloo

This solution is originally comes from https://github.com/CentroEPiaggio/moveit_advanced/commit/9b2c13b3d2d24a21b742f854f4a2f27a1f7a85b6

I also added few changes for CMake and launch files